### PR TITLE
fix: fixed wording of offices in mobile view

### DIFF
--- a/web/site/components/Sbc/Table/Address/index.vue
+++ b/web/site/components/Sbc/Table/Address/index.vue
@@ -70,7 +70,7 @@ const addresses = computed(() => {
     <div class="block sm:hidden">
       <div v-for="(row, index) in addresses" :key="index" :class="{'pt-3': index !== 0}">
         <div class="text-lg font-bold">
-          {{ t('labels.office') }}
+          {{ row.name }}
         </div>
 
         <div class="px-4 pt-2">


### PR DESCRIPTION
[Zenhub Ticket](https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/business-ar/292)

This PR is fixing an issue in my previous pr, https://github.com/bcgov/business-ar/pull/311, which involved updating the UI for mobile screens. 

On Mobile screens, I changed the Addresses and Directors sections to be dropdowns and to only contain one column.
<div style="display: flex; align-items: flex-start;">
  <img src="https://github.com/user-attachments/assets/57ab8067-67ea-46b4-b141-0ee4564cf189" alt="Before UI Change" width="200" />
  <img src="https://github.com/user-attachments/assets/d9edd081-97c7-41d6-89d3-355a7501df9c" alt="After UI Change" width="200" />
</div>

In doing so, I changed the offices in the Addresses section to just `Office`, instead of the actual name (Registered Office, Records Office). 

This PR fixes this.


 